### PR TITLE
Update favicon links

### DIFF
--- a/src/components/Layout.astro
+++ b/src/components/Layout.astro
@@ -21,6 +21,9 @@ const { language } = page;
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
 		<link rel="icon" type="image/svg+xml" href={`${websiteConfig.base}/favicon.svg`} />
+		<link rel="icon" type="image/png" href="{`${websiteConfig.base}/favicon-96x96.png" sizes="96x96" />
+		<link rel="shortcut icon" href="{`${websiteConfig.base}/favicon.ico" />
+		<link rel="apple-touch-icon" sizes="180x180" href="{`${websiteConfig.base}/apple-touch-icon.png" />
     <SEO page={page} />
   </head>
   <body class="body">

--- a/src/components/Layout.astro
+++ b/src/components/Layout.astro
@@ -20,7 +20,7 @@ const { language } = page;
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
-		<link rel="icon" type="image/svg+xml" href={`/${websiteConfig.base}/favicon.svg`} />
+		<link rel="icon" type="image/svg+xml" href={`${websiteConfig.base}/favicon.svg`} />
     <SEO page={page} />
   </head>
   <body class="body">

--- a/website.config.json
+++ b/website.config.json
@@ -1,6 +1,6 @@
 {
   "author": "Spaceship CO",
-  "base": "astro-theme-spaceship/",
+  "base": "/astro-theme-spaceship",
   "defaultLocale": "en",
   "description": "Ship your Second Brain into the Cyber-Space",
   "site": "https://aitorllj93.github.io",


### PR DESCRIPTION
When I build my site, I don't have a base path (straight from `me.github.io` instead of `me.github.io/my-astro-site`), so that field in `website.config.json` is empty. Because of this, the links to the site favicon get rendered as `<link rel="icon" type="image/svg+xml" href="//favicon.svg">` instead of just `/favicon.svg`.

I took the liberty of fixing that and creating a pull request. Furthermore, I added some more favicon links that some favicon generator sites add for SEO and mobile friendliness.